### PR TITLE
Replace [code] tags by "Automating Ghidra" series

### DIFF
--- a/20200707-automating-ghidra-part-2.md
+++ b/20200707-automating-ghidra-part-2.md
@@ -30,43 +30,43 @@ Even for an untrained eye, that data looks suspicious. And in fact it is, we onl
 We could now set the label for this data to be `Right_Parenthesis` but then we would miss the automate part and we would have to repeat the mundane job couple more times. So automation time...
 
 Let's start with defining and address where we want to start - for that we will use the already know function `toAddr` that will convert a string to an `Address` type that Ghidra knows and understands.
-[code]
-    addr = toAddr('00104b88')
 
-[/code]
+```
+    addr = toAddr('00104b88')
+```
 
 Next, we need to get our data. For that, first we will need to get hold of `Listing` object. We can get it directly from `currentProgram` that represents our loaded binary.
-[code]
-    l = currentProgram.getListing()
 
-[/code]
+```
+    l = currentProgram.getListing()
+```
 
 Now's the fun part. To get the data at a given address, we can use function `getDataAt` passing an address. We can get nothing or we can get a data but it would be uninitialized so let's cover those cases. For the first one, we will simply finish our work, and for the second one, we will just skip those bytes and move to the next one.
-[code]
+
+```
     d = l.getDataAt(addr)
     if d == None:
         break
     if not d.isDefined():
         addr = addr.add(d.length)
         continue
-
-[/code]
+```
 
 Ok. now - how we can get the value of the data. What we get from `getDataAt` is actually a `Data` object and it has a [rich API](https://ghidra.re/ghidra_docs/api/ghidra/program/model/listing/Data.html) and fortunately it has `getValue` function. We just need to convert those bytes to an ascii string.
-[code]
-    name = d.getValue().decode('hex').replace(' ', '_')
 
-[/code]
+```
+    name = d.getValue().decode('hex').replace(' ', '_')
+```
 
 Additionally, we convert spaces to underscores as labels, that we will like to set doesn't allow that, and one of the string has a space in it - yet I think that's a mistake as all the rest has underscores in case of spaces.
 
 So now the last part. How to set a label for the data to be our string? Again, simple when we look at the API. There's a method for that.
 
 We just need to obtain the primary symbol associated with our data (in this case it will be a label (it can be something else in other cases), and from that we set the name. In python it looks like this:
-[code]
-    d.getPrimarySymbol().setName(name, SourceType.USER_DEFINED)
 
-[/code]
+```
+    d.getPrimarySymbol().setName(name, SourceType.USER_DEFINED)
+```
 
 We just needed to provide the second parameter for the name stating from where the name is coming from - not sure why this is needed, but `USER_DEFINED` sounds about right. For the purpose of using this const we needed to import it `from ghidra.program.model.symbol import SourceType`.
 
@@ -75,7 +75,8 @@ Lastly, we move our `addr` to the next data by adjusting it by the data length. 
 Since we will be doing it in the loop, we need an exit condition. If we reach the address after the last such data, we exit.
 
 The full script is as follows:
-[code]
+
+```
     from ghidra.program.model.symbol import SourceType
 
     addr = toAddr('00104b88')
@@ -94,8 +95,7 @@ The full script is as follows:
 
         if addr >= toAddr('00104e13'):
     	   break
-
-[/code]
+```
 
 And this is how it works:
 

--- a/20241113-scripting-ghidra-set-equate.md
+++ b/20241113-scripting-ghidra-set-equate.md
@@ -28,7 +28,8 @@ While Ghidra includes a comprehensive list of common names and values, we often 
 ![](content/images/2024/11/image.webp)Initial disassembly code
 
 We can start the script by loading a list of hashes with their corresponding names. Here’s a list that we can use to feed into our script...
-[code]
+
+```
     # C:\Windows\System32\kernel32.dll
     AcquireSRWLockExclusive,0x4784e83e
     AcquireSRWLockShared,0x23c00487
@@ -43,10 +44,11 @@ We can start the script by loading a list of hashes with their corresponding nam
     AddRefActCtx,0x5d41574a
     AddSIDToBoundaryDescriptor,0x2a3a39ad
     ...
-[/code]
+```
 
 Saving this into `api_hashes.txt` we can move to the script.
-[code]
+
+```
     from ghidra.app.cmd.equate import SetEquateCmd
     from os import path
 
@@ -56,21 +58,23 @@ Saving this into `api_hashes.txt` we can move to the script.
     data = {}
     with open(file_name,'r') as f:
       data = dict([(v,k) for k,v in [l.split(',') for l in f.read().splitlines() if '#' not in l]])
-[/code]
+```
 
 This part of the script will read the aforementioned file and populate the variable `dict` with API hashes as keys and their corresponding names as values. Additionally, lines that start with `#` will be skipped, as these are provided in the file as comments.
 
 Once this setup is complete, we can start replacing hash values in the disassembly. In this example, the hashes appear at regular intervals, so we can use a simple loop with a predefined step. In a more complex scenario, we would need a more sophisticated approach to handle all cases.
-[code]
+
+```
     start_addr = 0x2ba
     end_addr = 0x66c
     step = 0x16
     for addr in range(start_addr, end_addr+1, step):
        #do the replace - code to follow
-[/code]
+```
 
 To replace a value with a name, we will use `SetEquateCmd` Ghidra APIs. But to use it, we need a couple of values.
-[code]
+
+```
     i = getInstructionAt(toAddr(addr))
     v = i.getScalar(1)
     key = v.toString(16, False, False, '0x', '')
@@ -78,14 +82,15 @@ To replace a value with a name, we will use `SetEquateCmd` Ghidra APIs. But to u
       continue
     name = data[key]
     e = SetEquateCmd(name, toAddr(addr), 1, v.getValue())
-[/code]
+```
 
 First, we extract the instruction at a specific address using `getInstructionAt` in conjunction with `toAddr`, which converts a number to an address.
 
 Next, we extract the hash used in the instruction `MOV dword ptr [RBP + local_214], 0x5c856c47`. Based on that value, we can find the corresponding name to replace the hash. Finally, we create a `SetEquateCmd` using the information we’ve gathered.
 
 To apply the change, we call `e.applyTo(currentProgram)`. And that’s it—the script is short but effective.
-[code]
+
+```
     from ghidra.app.cmd.equate import SetEquateCmd
     from os import path
 
@@ -108,7 +113,7 @@ To apply the change, we call `e.applyTo(currentProgram)`. And that’s it—the 
         name = data[key]
         e = SetEquateCmd(name, toAddr(addr), 1, v.getValue())
         e.applyTo(currentProgram)
-[/code]
+```
 
 We need to save it along with the `api_hashes.txt` file and run.
 

--- a/20241128-scripting-ghidra-create-data.md
+++ b/20241128-scripting-ghidra-create-data.md
@@ -20,7 +20,8 @@ Ghidra supports many distinct types and setting them correctly can help understa
 ![](content/images/2024/11/image-3.png)Data Type Chooser Dialog
 
 Lets check this part of the code.
-[code]
+
+```
     switchD_00400a48::sth_interesting
                 00400ea0 e8              ??           E8h
                 00400ea1 00              ??           00h
@@ -42,22 +43,24 @@ Lets check this part of the code.
                 00400eb1 00              ??           00h
                 00400eb2 00              ??           00h
                 00400eb3 00              ??           00h
-[/code]
+```
 
 The bytes define and offset that is used to address some code section in a different part of the assembly. We can apply an int type to them for better visibility. For this example we will use Ghidra’s flat API that is available  from Python.
 
 Let’s jump to the text editor.
-[code]
+
+```
     ptr_type = getDataTypes("int")[0]
-[/code]
+```
 
 First we use the `getDataTypes` method passing the type we want to apply to our bytes. This method returns an array, so we pick the first type returned.
 
 Next thing…oh wait, that’s already it. We can use `createData` with our type to convert.
-[code]
+
+```
     for addr in range(0x00400ea0,0x00400f14,4):
         createData(toAddr(addr), ptr_type)
-[/code]
+```
 
 To convert a value to an address we can use already known helper method - `toAddr`. Let’s see this code in action.
 


### PR DESCRIPTION
Hi!

Thank you for your articles/ blog posts.

Unfortunately not all code renders on your website. The `[code] ... [/code]` tags don't get converted to HTML and they also don't display as code when rendered by GitHub. So I replaced the tags by ```. This improves readability - at least for me.

HTH,
Mäh